### PR TITLE
add paste url functionality

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,6 +44,7 @@ class Paragraph {
       wrapper: 'ce-paragraph'
     };
     this.onKeyUp = this.onKeyUp.bind(this);
+    this.onPaste = this.onPaste.bind(this);
 
     /**
      * Placeholder for paragraph if it is first Block
@@ -87,6 +88,7 @@ class Paragraph {
     div.dataset.placeholder = this._placeholder;
 
     div.addEventListener('keyup', this.onKeyUp);
+    div.addEventListener('paste', this.onPaste);
 
     return div;
   }
@@ -142,17 +144,55 @@ class Paragraph {
     };
   }
 
+  handleConfiguredPaste(event) {
+    const data = {
+      text: event.detail.data.innerHTML
+    };
+    this.data = data;
+  }
+
+  handleDefaultPaste(event) {
+    const text = event.clipboardData.getData('Text');
+    if (text.match(/^https?:\/\//)) {
+      // url was pasted, we handle this event completely
+      event.preventDefault();
+      event.stopPropagation();
+
+      const selectedHtml = () => {
+        const selection = document.getSelection()
+        if (!selection.rangeCount) {
+          return '';
+        }
+        const container = document.createElement('div');
+        for (let i = 0; i < selection.rangeCount; i++) {
+          container.appendChild(selection.getRangeAt(i).cloneContents());
+        }
+        return container.innerHTML;
+      }
+
+      const url = text;
+      const linktext = selectedHtml() || url;
+      const linktag = `<a href="${url}">${linktext}</a>`;
+      window.document.execCommand('insertHTML', false, linktag);
+    }
+  }
+
   /**
    * On paste callback fired from Editor.
    *
    * @param {PasteEvent} event - event with pasted data
    */
   onPaste(event) {
-    const data = {
-      text: event.detail.data.innerHTML
-    };
-
-    this.data = data;
+    // detail is given, so this is a editorjs configured paste event
+    if (event.detail) {
+      this.handleConfiguredPaste(event);
+    } else if (this._element.innerHTML !== '') {
+      // we only care about the paste if the element is not empty
+      // reason being that other blocks may want to handle it, and
+      // editorjs creates a paragraph on enter click, so we automatically are
+      // always in a paragraph, albeit an empty one
+      this.handleDefaultPaste(event);
+    }
   }
 
   /**


### PR DESCRIPTION
paste url on selected text will create link element with selected text as linktext
paste url without selection will create link element with the url as linktext
paste url in empty paragraph will be ignored, because other tools may want to handle the paste event